### PR TITLE
Reduce the max entry point size to 350KB

### DIFF
--- a/config/webpack.prod.config.mjs
+++ b/config/webpack.prod.config.mjs
@@ -21,7 +21,7 @@ export const buildWebpackConfig = (paths) => {
     performance: {
       hints: 'warning',
       maxAssetSize: 204800,
-      maxEntrypointSize: 376832,
+      maxEntrypointSize: 358400,
     },
     plugins: [...webpackBaseConfig.plugins, new CompressionPlugin()],
   }


### PR DESCRIPTION
Several updates to third party components have lead to a leaner compile size for production builds. The current size of a production build is 311KiB. This PR reduces the maximum entry point size to 350KiB.