### PR TITLE
Update code review action to support jest scripts

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -59,6 +59,25 @@ jobs:
       - run: yarn test
         env:
           CI: true
+  jest:
+    runs-on: ubuntu-latest
+    needs: cache
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - uses: actions/cache@v3
+        with:
+          path: |
+            .yarn
+            node_modules
+          key: ${{ runner.os }}-${{ github.run_number }}
+      - run: yarn modules:enable
+      - run: yarn install --immutable
+      - run: yarn jest
+        env:
+          CI: true
   build:
     runs-on: ubuntu-latest
     needs: cache

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -7,30 +7,72 @@ on:
       - '!main'
       - '!develop'
 jobs:
-  lint:
+  cache:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: yarn
+      - run: yarn modules:enable
+      - run: yarn install --immutable
+      - uses: actions/cache@v3
+        with:
+          path: |
+            .yarn
+            node_modules
+          key: ${{ runner.os }}-${{ github.run_number }}
+  lint:
+    runs-on: ubuntu-latest
+    needs: cache
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - uses: actions/cache@v3
+        with:
+          path: |
+            .yarn
+            node_modules
+          key: ${{ runner.os }}-${{ github.run_number }}
+      - run: yarn modules:enable
       - run: yarn install --immutable
       - run: yarn lint
   test:
     runs-on: ubuntu-latest
+    needs: cache
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+      - uses: actions/cache@v3
+        with:
+          path: |
+            .yarn
+            node_modules
+          key: ${{ runner.os }}-${{ github.run_number }}
+      - run: yarn modules:enable
+      - run: yarn install --immutable
       - run: yarn test
         env:
           CI: true
   build:
     runs-on: ubuntu-latest
+    needs: cache
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+      - uses: actions/cache@v3
+        with:
+          path: |
+            .yarn
+            node_modules
+          key: ${{ runner.os }}-${{ github.run_number }}
+      - run: yarn modules:enable
+      - run: yarn install --immutable
       - run: yarn build


### PR DESCRIPTION
This PR optimizes the existing code review action by caching the yarn packages to be used by various steps. It caches it with modules:enabled, meaning that it is generating a node_modules folder. This allows for a new action within the script that will run all of the jest tests.