### PR TITLE
Update yarnrc

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,9 +9,6 @@ packageExtensions:
   stylelint-config-recommended-scss@*:
     peerDependencies:
       postcss: "*"
-  stylelint-config-standard-scss@*:
-    peerDependencies:
-      postcss: "*"
   stylelint@*:
     peerDependencies:
       "@stylelint/postcss-css-in-js": "*"


### PR DESCRIPTION
This PR removes the postcss peer dependency. It is no longer needed do to a dependancy updates.